### PR TITLE
NameError: "global name '_possix_fallocate' is not defined"

### DIFF
--- a/fallocate/__init__.py
+++ b/fallocate/__init__.py
@@ -21,7 +21,7 @@ try:
     def posix_fallocate(fd, offset, len):
         if isinstance(fd, file):
             fd = fd.fileno()
-        return _possix_fallocate(fd, offset, len)
+        return _posix_fallocate(fd, offset, len)
     posix_fallocate.__doc__ = _posix_fallocate.__doc__
 
     def posix_fadvise(fd, offset, len, advise):


### PR DESCRIPTION
Fix what looks like a typo that makes posix_fallocate unusable.
