### PR TITLE
Fix fallocate on rhel6/centos6.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ if sys.platform == "darwin":
     if find_in_file("/usr/include/sys/fcntl.h", "F_ALLOCATECONTIG"):
         defs.append(("HAVE_APPLE_F_ALLOCATECONTIG", None))
 else:
-    if find_in_glob("/usr/include/*/bits/fcntl.h", "fallocate"):
+    if find_in_glob("/usr/include/*/bits/fcntl.h", "fallocate") or find_in_glob("/usr/include/bits/fcntl.h", "fallocate"):
         defs.append(("HAVE_FALLOCATE", None))
     if find_in_file("/usr/include/fcntl.h", "posix_fallocate"):
         defs.append(("HAVE_POSIX_FALLOCATE", None))


### PR DESCRIPTION
On Redhat 6 or CentOS 6 I see following message:

```
lib/python2.7/site-packages/fallocate/__init__.py:15: UserWarning: fallocate(2) or OSX equivalent was not found on this system
  warnings.warn("fallocate(2) or OSX equivalent was not found on this system")
```

This is due to setup.py improperly parses `../bits/fcntl.h` file:

```
In [4]: g='/usr/include/*/bits/fcntl.h'

In [5]: glob.glob(g)
Out[5]: []

In [6]: g='/usr/include/bits/fcntl.h'

In [7]: glob.glob(g)
Out[7]: ['/usr/include/bits/fcntl.h']
```

This merge request fixes this issue.
