### PR TITLE
Provide FALLOC_FL_KEEP_SIZE, FALLOC_FL_PUNCH_HOLE constants in Python

### DIFF
--- a/fallocate/__init__.py
+++ b/fallocate/__init__.py
@@ -4,7 +4,6 @@ __version__ = "1.2.0"
 
 try:
     from ._fallocate import fallocate as _fallocate
-    from ._fallocate import FALLOC_FL_KEEP_SIZE, FALLOC_FL_PUNCH_HOLE
     def fallocate(fd, offset, len, mode=0):
         if isinstance(fd, file):
             fd = fd.fileno()
@@ -14,6 +13,10 @@ except ImportError:
     def fallocate(fd, offset, len, mode=0):
         """ fallocate(2) or OSX equivalent was not found on this system"""
         warnings.warn("fallocate(2) or OSX equivalent was not found on this system")
+try:
+    from ._fallocate import FALLOC_FL_KEEP_SIZE, FALLOC_FL_PUNCH_HOLE
+except ImportError:
+    pass
 
 try:
     from ._fallocate import posix_fallocate as _posix_fallocate


### PR DESCRIPTION
Noticed another issue. We defining those constants, but not providing them to the Python module.

Tested on python2/linux only. 
