### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ if sys.platform == "darwin":
     if find_in_file("/usr/include/sys/fcntl.h", "F_ALLOCATECONTIG"):
         defs.append(("HAVE_APPLE_F_ALLOCATECONTIG", None))
 else:
-    if find_in_glob("/usr/include/*/bits/fcntl.h", "fallocate") or find_in_glob("/usr/include/bits/fcntl.h", "fallocate"):
+    if find_in_glob("/usr/include/*/bits/fcntl.h", "fallocate") or find_in_glob("/usr/include/bits/fcntl*.h", "fallocate"):
         defs.append(("HAVE_FALLOCATE", None))
     if find_in_file("/usr/include/fcntl.h", "posix_fallocate"):
         defs.append(("HAVE_POSIX_FALLOCATE", None))


### PR DESCRIPTION
Linux fallocate is in fcntl-linux.h, expand glob to catch both files.  This is on OEL 7 ( RHEL variant ).  

I have tested this and went from receiving a warning to having fallocate exposed.  Could not use posix alternative since I need the KEEP_SIZE option.

```
(venv) [ew2193@gmon tarsplit]$ grep -Rl fallocate /usr/include/
/usr/include/asm/unistd_32.h
/usr/include/asm/unistd_64.h
/usr/include/asm/unistd_x32.h
/usr/include/asm-generic/unistd.h
/usr/include/linux/falloc.h
/usr/include/linux/fuse.h
/usr/include/bits/fcntl-linux.h
/usr/include/bits/syscall.h
/usr/include/fcntl.h
(venv) [ew2193@gmon tarsplit]$ uname -a
Linux gmon.rit.albany.edu 4.1.12-94.3.4.el7uek.x86_64 #2 SMP Mon May 15 13:57:28 PDT 2017 x86_64 x86_64 x86_64 GNU/Linux
```