### PR TITLE
Add import in README example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,6 +64,8 @@ Example:
 
 ::
 
+    from fallocate import fallocate
+
     # preallocate using fallocate a 1kb file
     with open("/tmp/test.file", "w+b") as f:
         fallocate(f, 0, 1024)


### PR DESCRIPTION
This just adds a line in the README with the import to use, making the example a no-brainer.